### PR TITLE
Fix Markdown example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ title: "Introduction"
 slug: "introduction"
 date: "2019-04-06"
 url: https://traffic.libsyn.com/lkajsdlkfjalksdjf/alskdjflkjasdf.mp3
-length: 206820339
+size: 206820339
 categories:
   - Ohh Oh
   - It's magic


### PR DESCRIPTION
The `size`variable should be used in the markdown frontmatter header instead of `length` or build will fail.