### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gatsby",
     "gatsby-plugin"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Gatsby Plugin for podcast feeds.",
   "main": "index.js",
   "scripts": {
@@ -17,5 +17,9 @@
   "dependencies": {
     "fs-extra": "^8.0.1",
     "rss": "^1.2.2"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/deathwebo/gatsby-plugin-podcast-feed"
   }
 }


### PR DESCRIPTION
Adding a repository field in package.json will enable a link in npm that points back to the source.

See here: https://docs.npmjs.com/files/package.json#repository

At the moment, [this package on npm](https://www.npmjs.com/package/gatsby-plugin-podcast-rss-feed) doesn't have a repository link and therefore it is very hard to find the source.

![image](https://user-images.githubusercontent.com/15177547/72771152-15453d00-3c54-11ea-87d9-83758d5585ba.png)

This also means that the source link in [the plugin's page](https://www.gatsbyjs.org/packages/gatsby-plugin-podcast-rss-feed/) on gatsbyjs.org isn't working.

![image](https://user-images.githubusercontent.com/15177547/72771476-188cf880-3c55-11ea-9b21-8d51e97e64f0.png)


